### PR TITLE
Add finalizedPoolCount field

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2,6 +2,7 @@ type Balancer @entity {
     id: ID!
     color: String!                                      # Bronze, Silver, Gold
     poolCount: Int!                                     # Number of pools
+    finalizedPoolCount: Int!                            # Number of finalized pools
     pools: [Pool!] @derivedFrom(field: "factoryID")
     txCount: BigInt!                                    # Number of txs
 }

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -11,6 +11,7 @@ export function handleNewPool(event: LOG_NEW_POOL): void {
     factory = new Balancer('1')
     factory.color = 'Bronze'
     factory.poolCount = 0
+    factory.finalizedPoolCount = 0
     factory.txCount = BigInt.fromI32(0)
   }
   factory.poolCount = factory.poolCount + 1

--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -217,6 +217,10 @@ export function handleFinalize(event: LOG_CALL): void {
   poolShare.save()
   */
 
+  let factory = Balancer.load('1')
+  factory.finalizedPoolCount = factory.finalizedPoolCount + 1
+  factory.save()
+
   let tx = event.transaction.hash.toHexString().concat('-').concat(event.logIndex.toString())
   let transaction = Transaction.load(tx)
   if (transaction == null) {


### PR DESCRIPTION
#### Add `finalizedPoolCount` field
This field is useful to the total of shared and private pools without having to query the whole list of pools. This change was tested on https://thegraph.com/explorer/subgraph/bonustrack/balancer