### PR TITLE
gulp uses call handler after all events processed

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "codegen": "graph codegen --output-dir src/types/",
     "build": "graph build",
     "deploy": "graph deploy balancer-labs/balancer --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy:beta": "graph deploy balancer-labs/balancer-beta --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:kovan": "graph deploy balancer-labs/balancer-kovan subgraph.kovan.yaml --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:ropsten": "graph deploy balancer-labs/balancer-ropsten subgraph.ropsten.yaml --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:local": "graph deploy balancer-labs/balancer-subgraph subgraph.yaml --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020"

--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -1,6 +1,6 @@
 import { BigInt, Address, Bytes, store } from '@graphprotocol/graph-ts'
 import { LOG_CALL, LOG_JOIN, LOG_EXIT, LOG_SWAP, Transfer, GulpCall } from '../types/templates/Pool/Pool'
-import { BToken } from '../types/templates/Pool/BToken'
+import { Pool as BPool } from '../types/templates/Pool/Pool'
 import {
   Balancer,
   Pool,
@@ -155,8 +155,8 @@ export function handleGulp(call: GulpCall): void {
 
   let address = call.inputs.token.toHexString();
 
-  let token = BToken.bind(Address.fromString(address))
-  let balanceCall = token.try_balanceOf(Address.fromString(poolId))
+  let bpool = BPool.bind(Address.fromString(poolId))
+  let balanceCall = bpool.try_getBalance(Address.fromString(address))
 
   let poolTokenId = poolId.concat('-').concat(address)
   let poolToken = PoolToken.load(poolTokenId)

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -68,9 +68,6 @@ templates:
         - event: LOG_CALL(indexed bytes4,indexed address,bytes)
           topic0: "0xcf5e7bd300000000000000000000000000000000000000000000000000000000"
           handler: handleUnbind
-        - event: LOG_CALL(indexed bytes4,indexed address,bytes)
-          topic0: "0x8c28cbe800000000000000000000000000000000000000000000000000000000"
-          handler: handleGulp
         - event: LOG_JOIN(indexed address,indexed address,uint256)
           handler: handleJoinPool
         - event: LOG_EXIT(indexed address,indexed address,uint256)
@@ -79,3 +76,6 @@ templates:
           handler: handleSwap
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+      callHandlers:
+        - function: gulp(address)
+          handler: handleGulp

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -68,9 +68,6 @@ templates:
         - event: LOG_CALL(indexed bytes4,indexed address,bytes)
           topic0: "0xcf5e7bd300000000000000000000000000000000000000000000000000000000"
           handler: handleUnbind
-        - event: LOG_CALL(indexed bytes4,indexed address,bytes)
-          topic0: "0x8c28cbe800000000000000000000000000000000000000000000000000000000"
-          handler: handleGulp
         - event: LOG_JOIN(indexed address,indexed address,uint256)
           handler: handleJoinPool
         - event: LOG_EXIT(indexed address,indexed address,uint256)
@@ -79,3 +76,6 @@ templates:
           handler: handleSwap
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+      callHandlers:
+        - function: gulp(address)
+          handler: handleGulp


### PR DESCRIPTION
Previously `gulp()` used an event handler and called `balanceOf()` to sync. This caused issues when gulps happened in the middle of a single tx, ex: swap -> gulp -> swap. Because the gulp would call balanceOf() from the end of the block and then the swap would update the graph balance afterwards.

Now a call handler using parity tracing is used for `gulp()` which ensures it is processed only after all event handlers process for a given block.