### PR TITLE
Add pool field "active"

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -12,6 +12,7 @@ type Pool @entity {
     controller: Bytes!                                  # Controller address
     publicSwap: Boolean!                                # isPublicSwap
     finalized: Boolean!                                 # isFinalized
+    active: Boolean!                                    # isActive
     swapFee: BigDecimal!                                # Swap Fees
     totalWeight: BigDecimal!
     totalShares: BigDecimal!                            # Total pool token shares

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -22,6 +22,7 @@ export function handleNewPool(event: LOG_NEW_POOL): void {
   pool.controller = event.params.caller
   pool.publicSwap = false
   pool.finalized = false
+  pool.active = true
   pool.swapFee = BigDecimal.fromString('0.000001')
   pool.totalWeight = ZERO_BD
   pool.totalShares = ZERO_BD


### PR DESCRIPTION
~~**WIP** I'm still waiting for the changes to fully sync on my subgraph to test it~~

My subgraph is fully sync with that change, i've tested and can confirm:
- All the pools with active=false have all their tokens with balance of 0
- All the pools with active=true have a balance on all their tokens with the exception of the pool `0x8e249b94a6df92dd33c56b623de3109c3eb867c9` where one token (DZAR) have 0 balance for some reason (but pool is active and swaps going on).

You can test it here:
https://thegraph.com/explorer/subgraph/bonustrack/balancer?query=Find%20unactive%20pools

Here is the API endpoint:
https://api.thegraph.com/subgraphs/name/bonustrack/balancer