### PR TITLE
Add tokensCount and holdersCount fields

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -22,6 +22,7 @@ type Pool @entity {
     shares: [PoolShare!] @derivedFrom(field: "poolId")
     createTime: Int!                                    # Block time pool was created
     tokensCount: BigInt!                                # Number of tokens in the pool
+    holdersCount: BigInt!                               # Number of addresses holding a positive balance of BPT
     joinsCount: BigInt!                                 # liquidity has been added
     exitsCount: BigInt!                                 # liquidity has been removed
     swapsCount: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -21,6 +21,7 @@ type Pool @entity {
     tokens: [PoolToken!] @derivedFrom(field: "poolId")
     shares: [PoolShare!] @derivedFrom(field: "poolId")
     createTime: Int!                                    # Block time pool was created
+    tokensCount: BigInt!                                # Number of tokens in the pool
     joinsCount: BigInt!                                 # liquidity has been added
     exitsCount: BigInt!                                 # liquidity has been removed
     swapsCount: BigInt!

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -29,6 +29,7 @@ export function handleNewPool(event: LOG_NEW_POOL): void {
   pool.liquidity = ZERO_BD
   pool.createTime = event.block.timestamp.toI32()
   pool.tokensCount = BigInt.fromI32(0)
+  pool.holdersCount = BigInt.fromI32(0)
   pool.joinsCount = BigInt.fromI32(0)
   pool.exitsCount = BigInt.fromI32(0)
   pool.swapsCount = BigInt.fromI32(0)

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -28,6 +28,7 @@ export function handleNewPool(event: LOG_NEW_POOL): void {
   pool.totalSwapVolume = ZERO_BD
   pool.liquidity = ZERO_BD
   pool.createTime = event.block.timestamp.toI32()
+  pool.tokensCount = BigInt.fromI32(0)
   pool.joinsCount = BigInt.fromI32(0)
   pool.exitsCount = BigInt.fromI32(0)
   pool.swapsCount = BigInt.fromI32(0)

--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -279,53 +279,70 @@ export function handleSwap(event: LOG_SWAP): void {
  ************************************/
 
  export function handleTransfer(event: Transfer): void {
+  let poolId = event.address.toHex()
 
-   let poolId = event.address.toHex()
+  const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
-   const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+  let isMint = event.params.src.toHex() == ZERO_ADDRESS
+  let isBurn = event.params.dst.toHex() == ZERO_ADDRESS
 
-   let isMint = event.params.src.toHex() == ZERO_ADDRESS
-   let isBurn = event.params.dst.toHex() == ZERO_ADDRESS
+  let poolShareFromId = poolId.concat('-').concat(event.params.src.toHex())
+  let poolShareFrom = PoolShare.load(poolShareFromId)
+  let poolShareFromBalance = poolShareFrom == null ? ZERO_BD : poolShareFrom.balance
 
-   let poolShareFromId = poolId.concat('-').concat(event.params.src.toHex())
-   let poolShareFrom = PoolShare.load(poolShareFromId)
+  let poolShareToId = poolId.concat('-').concat(event.params.dst.toHex())
+  let poolShareTo = PoolShare.load(poolShareToId)
+  let poolShareToBalance = poolShareTo == null ? ZERO_BD : poolShareTo.balance
 
-   let poolShareToId = poolId.concat('-').concat(event.params.dst.toHex())
-   let poolShareTo = PoolShare.load(poolShareToId)
+  let pool = Pool.load(poolId)
 
-   let pool = Pool.load(poolId)
+  if (isMint) {
+    if (poolShareTo == null) {
+      createPoolShareEntity(poolShareToId, poolId, event.params.dst.toHex())
+      poolShareTo = PoolShare.load(poolShareToId)
+    }
+    poolShareTo.balance += tokenToDecimal(event.params.amt.toBigDecimal(), 18)
+    poolShareTo.save()
+    pool.totalShares += tokenToDecimal(event.params.amt.toBigDecimal(), 18)
+  } else if (isBurn) {
+    if (poolShareFrom == null) {
+    createPoolShareEntity(poolShareFromId, poolId, event.params.src.toHex())
+    poolShareFrom = PoolShare.load(poolShareFromId)
+  }
+    poolShareFrom.balance -= tokenToDecimal(event.params.amt.toBigDecimal(), 18)
+    poolShareFrom.save()
+    pool.totalShares -= tokenToDecimal(event.params.amt.toBigDecimal(), 18)
+  } else {
+    if (poolShareTo == null) {
+      createPoolShareEntity(poolShareToId, poolId, event.params.dst.toHex())
+      poolShareTo = PoolShare.load(poolShareToId)
+    }
+    poolShareTo.balance += tokenToDecimal(event.params.amt.toBigDecimal(), 18)
+    poolShareTo.save()
 
-   if (isMint) {
-     if (poolShareTo == null) {
-       createPoolShareEntity(poolShareToId, poolId, event.params.dst.toHex())
-       poolShareTo = PoolShare.load(poolShareToId)
-     }
-     poolShareTo.balance += tokenToDecimal(event.params.amt.toBigDecimal(), 18)
-     poolShareTo.save()
-     pool.totalShares += tokenToDecimal(event.params.amt.toBigDecimal(), 18)
-   } else if (isBurn) {
-     if (poolShareFrom == null) {
-       createPoolShareEntity(poolShareFromId, poolId, event.params.src.toHex())
-       poolShareFrom = PoolShare.load(poolShareFromId)
-     }
-     poolShareFrom.balance -= tokenToDecimal(event.params.amt.toBigDecimal(), 18)
-     poolShareFrom.save()
-     pool.totalShares -= tokenToDecimal(event.params.amt.toBigDecimal(), 18)
-   } else {
-     if (poolShareTo == null) {
-       createPoolShareEntity(poolShareToId, poolId, event.params.dst.toHex())
-       poolShareTo = PoolShare.load(poolShareToId)
-     }
-     poolShareTo.balance += tokenToDecimal(event.params.amt.toBigDecimal(), 18)
-     poolShareTo.save()
+    if (poolShareFrom == null) {
+      createPoolShareEntity(poolShareFromId, poolId, event.params.src.toHex())
+      poolShareFrom = PoolShare.load(poolShareFromId)
+    }
+    poolShareFrom.balance -= tokenToDecimal(event.params.amt.toBigDecimal(), 18)
+    poolShareFrom.save()
+  }
 
-     if (poolShareFrom == null) {
-       createPoolShareEntity(poolShareFromId, poolId, event.params.src.toHex())
-       poolShareFrom = PoolShare.load(poolShareFromId)
-     }
-     poolShareFrom.balance -= tokenToDecimal(event.params.amt.toBigDecimal(), 18)
-     poolShareFrom.save()
-   }
+  if (
+    poolShareTo !== null
+    && poolShareTo.balance.notEqual(ZERO_BD)
+    && poolShareToBalance.equals(ZERO_BD)
+  ) {
+    pool.holdersCount += BigInt.fromI32(1)
+  }
 
-   pool.save()
- }
+  if (
+    poolShareFrom !== null
+    && poolShareFrom.balance.equals(ZERO_BD)
+    && poolShareFromBalance.notEqual(ZERO_BD)
+  ) {
+    pool.holdersCount -= BigInt.fromI32(1)
+  }
+
+  pool.save()
+}

--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -97,7 +97,7 @@ export function handleRebind(event: LOG_CALL): void {
     tokensList.push(tokenBytes)
   }
   pool.tokensList = tokensList
-
+  pool.tokensCount = BigInt.fromI32(tokensList.length)
 
   let address = Address.fromString(event.params.data.toHexString().slice(34,74))
   let denormWeight = hexToDecimal(event.params.data.toHexString().slice(138), 18)
@@ -137,6 +137,7 @@ export function handleUnbind(event: LOG_CALL): void {
   let index = tokensList.indexOf(tokenBytes)
   tokensList.splice(index, 1)
   pool.tokensList = tokensList
+  pool.tokensCount = BigInt.fromI32(tokensList.length)
 
 
   let address = Address.fromString(event.params.data.toHexString().slice(-40))


### PR DESCRIPTION
This PR add the field `tokensCount`, it's needed to filter pools by the number of underlying token (i need it now for suggesting pools with same tokens when you create one in PM).

And the field `holdersCount` so we can display the total holders count in the "Holders" tab on single pool page.

The changes seem to work but haven't tried in a fully sync subgraph yet (in progress)