### PR TITLE
Allow pools with more than 2 assets for calculate token price

### DIFF
--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -173,9 +173,8 @@ export function updatePoolLiquidity(id: string): void {
       let poolToken = PoolToken.load(poolTokenId)
 
       if (
-        pool.tokensCount.equals(BigInt.fromI32(2)) &&
         (tokenPrice.poolTokenId == poolTokenId || poolLiquidity.gt(tokenPrice.poolLiquidity)) &&
-        (tokenPriceId != WETH.toString() || hasUsdPrice)
+        (tokenPriceId != WETH.toString() || (pool.tokensCount.equals(BigInt.fromI32(2)) && hasUsdPrice))
       ) {
         tokenPrice.price = ZERO_BD
 


### PR DESCRIPTION
Allowing pools with more than 2 assets for calculate token price when it's not USDC or WETH. This give a wider coverage of the token price, this change been tested here: https://thegraph.com/explorer/subgraph/bonustrack/balancer
