### PR TITLE
Fix totalSwapVolume and totalSwapFee

### DIFF
--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -256,8 +256,8 @@ export function handleSwap(event: LOG_SWAP): void {
     totalSwapFee = totalSwapFee.plus(swapFeeValue)
 
     let factory = Balancer.load('1')
-    factory.totalSwapVolume = factory.totalSwapVolume.minus(pool.totalSwapVolume).plus(totalSwapVolume)
-    factory.totalSwapFee = factory.totalSwapFee.minus(pool.totalSwapFee).plus(totalSwapFee)
+    factory.totalSwapVolume = factory.totalSwapVolume.plus(swapValue)
+    factory.totalSwapFee = factory.totalSwapFee.plus(swapFeeValue)
     factory.save()
 
     pool.totalSwapVolume = totalSwapVolume

--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -242,7 +242,7 @@ export function handleSwap(event: LOG_SWAP): void {
   }
 
   let pool = Pool.load(poolId)
-  let tokenPrice = TokenPrice.load(tokenIn)
+  let tokenPrice = TokenPrice.load(tokenOut)
   let totalSwapVolume = pool.totalSwapVolume
   let totalSwapFee = pool.totalSwapFee
   let liquidity = pool.liquidity
@@ -250,7 +250,7 @@ export function handleSwap(event: LOG_SWAP): void {
   let swapFeeValue = ZERO_BD
 
   if (tokenPrice !== null) {
-    swapValue = tokenPrice.price.times(tokenAmountIn)
+    swapValue = tokenPrice.price.times(tokenAmountOut)
     swapFeeValue = swapValue.times(pool.swapFee)
     totalSwapVolume = totalSwapVolume.plus(swapValue)
     totalSwapFee = totalSwapFee.plus(swapFeeValue)


### PR DESCRIPTION
~~There was an issue the way i calculated `totalSwapVolume` and `totalSwapFee`, this PR should fix it. Total liquidity look fine.~~

~~Edit: still seeing some issue related to STA pool will update the PR.~~

I'm now using tokenOut to price swap volume / swap fee instead of tokenIn. TokenIn were incorrectly priced with STA flash loan. This is the results i get with tokenOut after a full resync: 

Total liquidity from all pools: $317,400,824
Total swap fee all pools since begining: $2,564,343
Total swap volume all pools since begining: $879,652,510