### PR TITLE
Fix swap value with unpriced token out

### DIFF
--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -251,6 +251,11 @@ export function handleSwap(event: LOG_SWAP): void {
 
   let pool = Pool.load(poolId)
   let tokenPrice = TokenPrice.load(tokenOut)
+  let tokenAmount = tokenAmountOut
+  if (tokenPrice == null) {
+    tokenPrice = TokenPrice.load(tokenIn)
+    tokenAmount = tokenAmountIn
+  }
   let totalSwapVolume = pool.totalSwapVolume
   let totalSwapFee = pool.totalSwapFee
   let liquidity = pool.liquidity
@@ -258,7 +263,7 @@ export function handleSwap(event: LOG_SWAP): void {
   let swapFeeValue = ZERO_BD
 
   if (tokenPrice !== null) {
-    swapValue = tokenPrice.price.times(tokenAmountOut)
+    swapValue = tokenPrice.price.times(tokenAmount)
     swapFeeValue = swapValue.times(pool.swapFee)
     totalSwapVolume = totalSwapVolume.plus(swapValue)
     totalSwapFee = totalSwapFee.plus(swapFeeValue)


### PR DESCRIPTION
Fix issue with swap value not being recognized when token out don't have price, now it will fallback to token in.
https://pools.balancer.exchange/#/pool/0x6d59cf780d70927f022e3b827f31d6a6235a8d20/swaps
https://pools.balancer.exchange/#/pool/0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb/swaps

Sync in progress: https://thegraph.com/explorer/subgraph/balancer-labs/balancer-beta?version=pending
https://thegraph.com/explorer/subgraph/balancer-labs/balancer-kovan?version=pending