### PR TITLE
combine graph-node docker-compose with ganache for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ src/types/
 yarn-error.log
 .idea
 .vscode
+data/ipfs
+data/postgres

--- a/README.md
+++ b/README.md
@@ -17,24 +17,7 @@ Only the factory address is needed in subgraph.yaml, new pool addresses are auto
 
 ### Services
 
-Start a ganache chain using 0.0.0.0 as a host so docker can connect
-
-```
-ganache-cli -h 0.0.0.0 -d -l 4294967295 --allowUnlimitedContractSize
-```
-
-Run a local graph node
-
-```
-git clone https://github.com/graphprotocol/graph-node/
-```
-
-Update ethereum value in docker-compose.yml to `ganache:http://host.docker.internal:8545`
-
-```
-cd graph-node/docker
-```
-
+Start a ganache chain and a graph node by running
 ```
 docker-compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3'
+services:
+  ganache:
+    image: trufflesuite/ganache-cli:v6.10.1
+    ports:
+      - "8545:8545"
+    # Nota Bene - the mnemonic below is *INSECURE* and shouldn't be used for real funds, only local development
+    #             it serves only to create deterministic contract addresses that can be shared with subgraph
+    command: ganache-cli --mnemonic "album wire record stuff abandon mesh museum piece bean allow refuse below"
+  graph-node:
+    image: graphprotocol/graph-node
+    ports:
+      - '8000:8000'
+      - '8001:8001'
+      - '8020:8020'
+      - '8030:8030'
+      - '8040:8040'
+    depends_on:
+      - ipfs
+      - postgres
+      - ganache
+    environment:
+      postgres_host: postgres
+      postgres_user: graph-node
+      postgres_pass: let-me-in
+      postgres_db: graph-node
+      ipfs: 'ipfs:5001'
+      #ethereum: 'mainnet:http://host.docker.internal:8545'
+      ethereum: 'ganache:http://ganache:8545'
+      RUST_LOG: info
+  ipfs:
+    image: ipfs/go-ipfs:v0.4.23
+    ports:
+      - '5001:5001'
+    volumes:
+      - ./data/ipfs:/data/ipfs
+  postgres:
+    image: postgres
+    ports:
+      - '5432:5432'
+    command: ["postgres", "-cshared_preload_libraries=pg_stat_statements"]
+    environment:
+      POSTGRES_USER: graph-node
+      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_DB: graph-node
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
I propose using a docker-compose file to start up both graph-node services, and ganache for local development - since graph-node vendors a docker-image, we don't have to clone that repo in order to use it

I used a mnemonic in the docker-compose ganache service declaration (the same one that is in the merkle redeem project) so we can add a subgraph.ganache.yml with consistent contract addresses (since they are deterministically created)