### PR TITLE
Track transfers of CRP ownership

### DIFF
--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -1,7 +1,7 @@
 import { Address, BigInt, BigDecimal } from '@graphprotocol/graph-ts'
 import { LOG_NEW_POOL } from '../types/Factory/Factory'
 import { Balancer, Pool } from '../types/schema'
-import { Pool as PoolContract } from '../types/templates'
+import { Pool as PoolContract, CrpController as CrpControllerContract } from '../types/templates'
 import {
   ZERO_BD,
   isCrp,
@@ -40,6 +40,9 @@ export function handleNewPool(event: LOG_NEW_POOL): void {
     pool.crpController = Address.fromString(getCrpController(crp))
     pool.rights = getCrpRights(crp)
     pool.cap = getCrpCap(crp)
+
+    // Listen for any future crpController changes.
+    CrpControllerContract.create(event.params.caller)
   }
   pool.controller = event.params.caller
   pool.publicSwap = false

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -44,7 +44,7 @@ if (network == 'rinkeby') {
   CRP_FACTORY = '0xA3F9145CB0B50D907930840BB2dcfF4146df8Ab4'
 }
 
-export function hexToDecimal(hexString: String, decimals: i32): BigDecimal {
+export function hexToDecimal(hexString: string, decimals: i32): BigDecimal {
   let bytes = Bytes.fromHexString(hexString).reverse() as Bytes
   let bi = BigInt.fromUnsignedBytes(bytes)
   let scale = BigInt.fromI32(10).pow(decimals as u8).toBigDecimal()
@@ -283,6 +283,12 @@ export function isCrp(address: Address): boolean {
   let isCrp = crpFactory.try_isCrp(address)
   if (isCrp.reverted) return false
   return isCrp.value
+}
+
+export function getCrpUnderlyingPool(crp: ConfigurableRightsPool): string | null {
+  let bPool = crp.try_bPool()
+  if (bPool.reverted) return null;
+  return bPool.value.toHexString()
 }
 
 export function getCrpController(crp: ConfigurableRightsPool): string | null {

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -83,3 +83,21 @@ templates:
       callHandlers:
         - function: gulp(address)
           handler: handleGulp
+  - kind: ethereum/contract
+    name: CrpController
+    network: kovan
+    source:
+      abi: ConfigurableRightsPool
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/pool.ts
+      entities:
+        - Pool
+      abis:
+        - name: ConfigurableRightsPool
+          file: ./abis/ConfigurableRightsPool.json
+      eventHandlers:
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleSetCrpController

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -80,3 +80,21 @@ templates:
           handler: handleSwap
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+  - kind: ethereum/contract
+    name: CrpController
+    network: rinkeby
+    source:
+      abi: ConfigurableRightsPool
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/pool.ts
+      entities:
+        - Pool
+      abis:
+        - name: ConfigurableRightsPool
+          file: ./abis/ConfigurableRightsPool.json
+      eventHandlers:
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleSetCrpController

--- a/subgraph.ropsten.yaml
+++ b/subgraph.ropsten.yaml
@@ -80,3 +80,21 @@ templates:
           handler: handleSwap
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+  - kind: ethereum/contract
+    name: CrpController
+    network: ropsten
+    source:
+      abi: ConfigurableRightsPool
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/pool.ts
+      entities:
+        - Pool
+      abis:
+        - name: ConfigurableRightsPool
+          file: ./abis/ConfigurableRightsPool.json
+      eventHandlers:
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleSetCrpController

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -83,3 +83,21 @@ templates:
       callHandlers:
         - function: gulp(address)
           handler: handleGulp
+  - kind: ethereum/contract
+    name: CrpController
+    network: mainnet
+    source:
+      abi: ConfigurableRightsPool
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/pool.ts
+      entities:
+        - Pool
+      abis:
+        - name: ConfigurableRightsPool
+          file: ./abis/ConfigurableRightsPool.json
+      eventHandlers:
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleSetCrpController


### PR DESCRIPTION
The subgraph currently doesn't track any changes in CRP ownership which means that all pools which are transferred do not show up under "My pools" in the Balancer UI (and instead they're still shown to the original owner) and will be inaccessible unless whitelisted by the Balancer team.

This PR sets up a listener on each CRP to track these changes and update `pool.crpController` accordingly.

fixes #64 